### PR TITLE
Feature/specify container

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ import { TransitionGroup } from "react-transition-group";
 import App from "./App";
 
 ReactDOM.render(
-  <ModalProvider container={TransitionGroup}>
+  <ModalProvider rootComponent={TransitionGroup}>
     <App />
   </ModalProvider>,
   document.getElementById("root")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal-hook",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "React hook for showing modal windows",
   "author": "mpontus",
   "license": "MIT",

--- a/src/ModalProvider.tsx
+++ b/src/ModalProvider.tsx
@@ -7,9 +7,9 @@ import { ModalRoot } from "./ModalRoot";
  */
 export interface ModalProviderProps {
   /**
-   * Container component for modals that will be passed to ModalRoot
+   * Container component for modal nodes
    */
-  container?: React.ComponentType<any>;
+  rootComponent?: React.ComponentType<any>;
 
   /**
    * Subtree that will receive modal context
@@ -22,7 +22,10 @@ export interface ModalProviderProps {
  *
  * Provides modal context and renders ModalRoot.
  */
-export const ModalProvider = ({ container, children }: ModalProviderProps) => {
+export const ModalProvider = ({
+  rootComponent,
+  children
+}: ModalProviderProps) => {
   const [modals, setModals] = useState<Record<string, ModalType>>({});
   const showModal = useCallback(
     (key: string, modal: ModalType) =>
@@ -47,7 +50,7 @@ export const ModalProvider = ({ container, children }: ModalProviderProps) => {
     <ModalContext.Provider value={contextValue}>
       <React.Fragment>
         {children}
-        <ModalRoot modals={modals} container={container} />
+        <ModalRoot modals={modals} component={rootComponent} />
       </React.Fragment>
     </ModalContext.Provider>
   );

--- a/src/ModalProvider.tsx
+++ b/src/ModalProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useMemo, isValidElement } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import { ModalType, ModalContext } from "./ModalContext";
 import { ModalRoot } from "./ModalRoot";
 

--- a/src/ModalProvider.tsx
+++ b/src/ModalProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useMemo } from "react";
+import React, { useCallback, useState, useMemo, isValidElement } from "react";
 import { ModalType, ModalContext } from "./ModalContext";
 import { ModalRoot } from "./ModalRoot";
 
@@ -32,6 +32,12 @@ export const ModalProvider = ({
   rootComponent,
   children
 }: ModalProviderProps) => {
+  if (container && !(container instanceof HTMLElement)) {
+    throw new Error(`Container must specify DOM element to mount modal root into.
+    
+    This behavior has changed in 3.0.0. Please use \`rootComponent\` prop instead.
+    See: https://github.com/mpontus/react-modal-hook/issues/18`);
+  }
   const [modals, setModals] = useState<Record<string, ModalType>>({});
   const showModal = useCallback(
     (key: string, modal: ModalType) =>

--- a/src/ModalProvider.tsx
+++ b/src/ModalProvider.tsx
@@ -7,6 +7,11 @@ import { ModalRoot } from "./ModalRoot";
  */
 export interface ModalProviderProps {
   /**
+   * Specifies the root element to render modals into
+   */
+  container?: Element;
+
+  /**
    * Container component for modal nodes
    */
   rootComponent?: React.ComponentType<any>;
@@ -23,6 +28,7 @@ export interface ModalProviderProps {
  * Provides modal context and renders ModalRoot.
  */
 export const ModalProvider = ({
+  container,
   rootComponent,
   children
 }: ModalProviderProps) => {
@@ -50,7 +56,11 @@ export const ModalProvider = ({
     <ModalContext.Provider value={contextValue}>
       <React.Fragment>
         {children}
-        <ModalRoot modals={modals} component={rootComponent} />
+        <ModalRoot
+          modals={modals}
+          component={rootComponent}
+          container={container}
+        />
       </React.Fragment>
     </ModalContext.Provider>
   );

--- a/src/ModalRoot.tsx
+++ b/src/ModalRoot.tsx
@@ -18,7 +18,7 @@ interface ModalRootProps {
    * used by defualt, specifying a different component can change the way modals
    * are rendered across the whole application.
    */
-  container?: React.ComponentType<any>;
+  component?: React.ComponentType<any>;
 }
 
 /**
@@ -48,7 +48,7 @@ const ModalRenderer = memo(({ component, ...rest }: ModalRendererProps) =>
  * Renders modals using react portal.
  */
 export const ModalRoot = memo(
-  ({ modals, container: Container = React.Fragment }: ModalRootProps) => {
+  ({ modals, component: RootComponent = React.Fragment }: ModalRootProps) => {
     const [mountNode, setMountNode] = useState<Element | undefined>(undefined);
 
     // This effect will not be ran in the server environment
@@ -56,11 +56,11 @@ export const ModalRoot = memo(
 
     return mountNode
       ? ReactDOM.createPortal(
-          <Container>
+          <RootComponent>
             {Object.keys(modals).map(key => (
               <ModalRenderer key={key} component={modals[key]} />
             ))}
-          </Container>,
+          </RootComponent>,
           document.body
         )
       : null;

--- a/src/ModalRoot.tsx
+++ b/src/ModalRoot.tsx
@@ -19,6 +19,11 @@ interface ModalRootProps {
    * are rendered across the whole application.
    */
   component?: React.ComponentType<any>;
+
+  /**
+   * Specifies the root element to render modals into
+   */
+  container?: Element;
 }
 
 /**
@@ -48,11 +53,15 @@ const ModalRenderer = memo(({ component, ...rest }: ModalRendererProps) =>
  * Renders modals using react portal.
  */
 export const ModalRoot = memo(
-  ({ modals, component: RootComponent = React.Fragment }: ModalRootProps) => {
+  ({
+    modals,
+    container,
+    component: RootComponent = React.Fragment
+  }: ModalRootProps) => {
     const [mountNode, setMountNode] = useState<Element | undefined>(undefined);
 
     // This effect will not be ran in the server environment
-    useEffect(() => setMountNode(document.body));
+    useEffect(() => setMountNode(container || document.body));
 
     return mountNode
       ? ReactDOM.createPortal(
@@ -61,7 +70,7 @@ export const ModalRoot = memo(
               <ModalRenderer key={key} component={modals[key]} />
             ))}
           </RootComponent>,
-          document.body
+          mountNode
         )
       : null;
   }

--- a/src/__tests__/ModalProvider.tsx
+++ b/src/__tests__/ModalProvider.tsx
@@ -1,7 +1,14 @@
 import React from "react";
-import { render, fireEvent, flushEffects } from "react-testing-library";
+import {
+  cleanup,
+  render,
+  fireEvent,
+  flushEffects
+} from "react-testing-library";
 import { ModalProvider, useModal } from "..";
 import "jest-dom/extend-expect";
+
+afterEach(cleanup);
 
 describe("custom container prop", () => {
   const RootComponent: React.SFC = ({ children }) => (
@@ -27,5 +34,22 @@ describe("custom container prop", () => {
     expect(getByTestId("custom-root")).toContainElement(
       getByText("This is a modal")
     );
+  });
+
+  it("should render modals inside the specified root element", () => {
+    const customRoot = document.createElement("div");
+
+    document.body.appendChild(customRoot);
+
+    const { getByText } = render(
+      <ModalProvider container={customRoot}>
+        <App />
+      </ModalProvider>
+    );
+
+    fireEvent.click(getByText("Show modal"));
+    flushEffects();
+
+    expect(customRoot).toContainElement(getByText("This is a modal"));
   });
 });

--- a/src/__tests__/ModalProvider.tsx
+++ b/src/__tests__/ModalProvider.tsx
@@ -10,6 +10,15 @@ import "jest-dom/extend-expect";
 
 afterEach(cleanup);
 
+beforeEach(() => {
+  jest.spyOn(console, "error");
+  (global.console.error as any).mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (global.console.error as any).mockRestore();
+});
+
 describe("custom container prop", () => {
   const RootComponent: React.SFC = ({ children }) => (
     <div data-testid="custom-root">{children}</div>
@@ -51,5 +60,22 @@ describe("custom container prop", () => {
     flushEffects();
 
     expect(customRoot).toContainElement(getByText("This is a modal"));
+  });
+
+  it("should throw an error when `container` does not specify a DOM elemnet", () => {
+    expect(() => {
+      render(
+        <ModalProvider container={React.Fragment as any}>
+          <App />
+        </ModalProvider>
+      );
+      flushEffects();
+    }).toThrowError(
+      expect.objectContaining({
+        message: expect.stringMatching(
+          /Container must specify DOM element to mount modal root into/
+        )
+      })
+    );
   });
 });

--- a/src/__tests__/ModalProvider.tsx
+++ b/src/__tests__/ModalProvider.tsx
@@ -4,8 +4,8 @@ import { ModalProvider, useModal } from "..";
 import "jest-dom/extend-expect";
 
 describe("custom container prop", () => {
-  const Container: React.SFC = ({ children }) => (
-    <div data-testid="custom-container">{children}</div>
+  const RootComponent: React.SFC = ({ children }) => (
+    <div data-testid="custom-root">{children}</div>
   );
 
   const App = () => {
@@ -14,9 +14,9 @@ describe("custom container prop", () => {
     return <button onClick={showModal}>Show modal</button>;
   };
 
-  it("should render modals inside custom container", () => {
+  it("should render modals inside custom root component", () => {
     const { getByTestId, getByText } = render(
-      <ModalProvider container={Container}>
+      <ModalProvider rootComponent={RootComponent}>
         <App />
       </ModalProvider>
     );
@@ -24,7 +24,7 @@ describe("custom container prop", () => {
     fireEvent.click(getByText("Show modal"));
     flushEffects();
 
-    expect(getByTestId("custom-container")).toContainElement(
+    expect(getByTestId("custom-root")).toContainElement(
       getByText("This is a modal")
     );
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
 export * from "./ModalContext";
 export * from "./ModalProvider";
-export * from "./ModalRoot";
 export * from "./useModal";


### PR DESCRIPTION
This PR makes it possible to specify a custom mount node for the portal component.

To conform with conventions established in [`React.createPortal`](https://reactjs.org/docs/portals.html) and [MUI](https://material-ui.com/api/popper/#props) `container` prop has been renamed to `rootComponent` and reused for this purpose.

- [x] Rename `ModalProvider#container` prop to `rootComponent`
- [x] Introduce `ModalProvider#container` prop to specify DOM element to mount modals into
- [x] Add prop validation logic to `ModalProvider` to help users transition after the breaking change
- [x] Unexpose `ModalRoot` to prevent unexpected use-cases
- [ ] Update documentation

Fixes #18