### PR TITLE
fix: prevent unnecessary re-render

### DIFF
--- a/src/ModalProvider.tsx
+++ b/src/ModalProvider.tsx
@@ -51,6 +51,9 @@ export const ModalProvider = ({
   const hideModal = useCallback(
     (key: string) =>
       setModals(modals => {
+        if (!modals[key]) {
+          return modals;
+        }
         const newModals = { ...modals };
         delete newModals[key];
         return newModals;


### PR DESCRIPTION
You shouldn't modify state object if it is not changing. Returning new empty object causes re-render.