### PR TITLE
Add displayName to modal context

### DIFF
--- a/src/ModalContext.ts
+++ b/src/ModalContext.ts
@@ -31,3 +31,4 @@ export const ModalContext = React.createContext<ModalContextType>({
   showModal: invariantViolation,
   hideModal: invariantViolation
 });
+ModalContext.displayName = 'ModalContext';


### PR DESCRIPTION
The default displayName for a react context is `Context` so in the react devtools we get

![image](https://user-images.githubusercontent.com/709773/102026920-b2c5d400-3e05-11eb-829c-3b7ae2eaf45f.png)

This can make it difficult to navigate the react devtools when there are a lot of contexts in play. This PR adds a displayName to the ModalContext meaning we end up with 
![image](https://user-images.githubusercontent.com/709773/102026936-d0933900-3e05-11eb-9390-8e4bd6012679.png)

https://reactjs.org/docs/context.html#contextdisplayname
